### PR TITLE
Fix IEnvironment interface naming and default parameter

### DIFF
--- a/cloud_components/cloud/aws/facade.py
+++ b/cloud_components/cloud/aws/facade.py
@@ -3,7 +3,7 @@ from cloud_components.common.interface.cloud.event import IEvent
 from cloud_components.common.interface.cloud.function import IFunction
 from cloud_components.common.interface.cloud.queue import IQueue
 from cloud_components.common.interface.cloud.storage import IStorage
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 from cloud_components.common.interface.libs.logger import ILogger
 from cloud_components.cloud.aws.factory.event_factory import Eventfactory
 from cloud_components.cloud.aws.factory.function_factory import FunctionFactory
@@ -12,7 +12,7 @@ from cloud_components.cloud.aws.factory.storage_factory import StorageFactory
 
 
 class AWSFacade(ICloudFacade):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/cloud/aws/factory/event_factory.py
+++ b/cloud_components/cloud/aws/factory/event_factory.py
@@ -4,11 +4,11 @@ from cloud_components.cloud.aws.repository.sns import Sns
 from cloud_components.common.interface.factory import IFactory
 from cloud_components.common.interface.cloud.event import IEvent
 from cloud_components.common.interface.libs.logger import ILogger
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 
 
 class Eventfactory(IFactory[IEvent]):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/cloud/aws/factory/function_factory.py
+++ b/cloud_components/cloud/aws/factory/function_factory.py
@@ -4,11 +4,11 @@ from cloud_components.cloud.aws.repository.lambda_function import Lambda
 from cloud_components.common.interface.factory import IFactory
 from cloud_components.common.interface.cloud.function import IFunction
 from cloud_components.common.interface.libs.logger import ILogger
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 
 
 class FunctionFactory(IFactory[IFunction]):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/cloud/aws/factory/queue_factory.py
+++ b/cloud_components/cloud/aws/factory/queue_factory.py
@@ -3,12 +3,12 @@ import boto3
 from cloud_components.common.interface.factory import IFactory
 from cloud_components.common.interface.cloud.queue import IQueue
 from cloud_components.common.interface.libs.logger import ILogger
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 from cloud_components.cloud.aws.repository.sqs import Sqs
 
 
 class QueueFactory(IFactory[IQueue]):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/cloud/aws/factory/storage_factory.py
+++ b/cloud_components/cloud/aws/factory/storage_factory.py
@@ -1,13 +1,13 @@
 import boto3
 from cloud_components.common.interface.factory import IFactory
 from cloud_components.common.interface.cloud.storage import IStorage
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 from cloud_components.common.interface.libs.logger import ILogger
 from cloud_components.cloud.aws.repository.s3 import S3
 
 
 class StorageFactory(IFactory[IStorage]):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/cloud/gcp/facade.py
+++ b/cloud_components/cloud/gcp/facade.py
@@ -3,13 +3,13 @@ from cloud_components.common.interface.cloud.event import IEvent
 from cloud_components.common.interface.cloud.function import IFunction
 from cloud_components.common.interface.cloud.queue import IQueue
 from cloud_components.common.interface.cloud.storage import IStorage
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 from cloud_components.common.interface.libs.logger import ILogger
 from cloud_components.cloud.gcp.factory.storage_factory import StorageFactory
 
 
 class GCSFacade(ICloudFacade):
-    def __init__(self, logger: ILogger, env: IEnviroment) -> None:
+    def __init__(self, logger: ILogger, env: IEnvironment) -> None:
         self.logger = logger
         self.env = env
 

--- a/cloud_components/common/interface/libs/enviroment.py
+++ b/cloud_components/common/interface/libs/enviroment.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Union
 
 
-class IEnviroment(ABC):  # pylint: disable=C0115
+class IEnvironment(ABC):  # pylint: disable=C0115
     @abstractmethod
     def load(self) -> None:  # pylint: disable=C0116
         raise NotImplementedError
@@ -12,6 +12,6 @@ class IEnviroment(ABC):  # pylint: disable=C0115
         self,
         env_name: str,
         cast: Union[Callable[[Any], Any], None] = None,
-        defalt: Union[Any, None] = None,
+        default: Union[Any, None] = None,
     ) -> Any:
         raise NotImplementedError

--- a/cloud_components/libs/env/env.py
+++ b/cloud_components/libs/env/env.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Callable, Union
 
-from cloud_components.common.interface.libs.enviroment import IEnviroment
+from cloud_components.common.interface.libs.enviroment import IEnvironment
 from cloud_components.common.interface.libs.logger import ILogger
 
 try:
@@ -10,7 +10,7 @@ except ImportError as err:
     pass
 
 
-class Dotenv(IEnviroment):  # pylint: disable=C0115
+class Dotenv(IEnvironment):  # pylint: disable=C0115
     def __init__(self, logger: ILogger) -> None:
         self.logger = logger
 
@@ -22,7 +22,7 @@ class Dotenv(IEnviroment):  # pylint: disable=C0115
         self,
         env_name: str,
         cast: Union[Callable[[Any], Any], None] = None,
-        defalt: Union[Any, None] = None,
+        default: Union[Any, None] = None,
     ) -> Any:
-        value = os.getenv(env_name, defalt)
+        value = os.getenv(env_name, default)
         return value if not cast else cast(value)


### PR DESCRIPTION
## Summary
- rename `IEnviroment` to `IEnvironment`
- fix parameter name from `defalt` to `default`
- update imports across facades and factories

## Testing
- `pip install -e .`
- `pip install boto3`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684335230bec8327b11714e986a66d3b