### PR TITLE
Implement AWS lambda and sqs features

### DIFF
--- a/cloud_components/cloud/aws/repository/lambda_function.py
+++ b/cloud_components/cloud/aws/repository/lambda_function.py
@@ -24,4 +24,17 @@ class Lambda(IFunction):
         self._name = value
 
     def execute(self, payload: bytes):
-        raise NotImplementedError
+        try:
+            response = self.connection.invoke(
+                FunctionName=self.function,
+                Payload=payload,
+            )
+            result = response.get("Payload")
+            if hasattr(result, "read"):
+                return result.read()
+            return result
+        except Exception as err:  # pylint: disable=W0718
+            self.logger.error(
+                f"An error occurred when try to execute a function. Error detail: {err}"
+            )
+            return None

--- a/cloud_components/cloud/aws/repository/sqs.py
+++ b/cloud_components/cloud/aws/repository/sqs.py
@@ -35,4 +35,16 @@ class Sqs(IQueue):
         return True
 
     def receive_message(self) -> str:
-        raise NotImplementedError
+        try:
+            messages = self.queue.receive_messages(MaxNumberOfMessages=1)
+            if not messages:
+                return ""
+            message = messages[0]
+            body = message.body
+            message.delete()
+            return body
+        except ClientError as err:
+            self.logger.error(
+                f"An error occurred when try to receive a message. Error detail: {err}"
+            )
+            return ""

--- a/tests/unit/cloud/aws/test_lambda_repository.py
+++ b/tests/unit/cloud/aws/test_lambda_repository.py
@@ -1,3 +1,4 @@
+# pylint: disable=attribute-defined-outside-init
 from unittest.mock import Mock
 from botocore.exceptions import ClientError
 

--- a/tests/unit/cloud/aws/test_lambda_repository.py
+++ b/tests/unit/cloud/aws/test_lambda_repository.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+from botocore.exceptions import ClientError
+
+from cloud_components.cloud.aws.repository.lambda_function import Lambda
+
+
+class TestLambda:
+    def setup_method(self):
+        self.connection = Mock(name="connection")
+        self.logger = Mock(name="logger")
+        self.instance = Lambda(connection=self.connection, logger=self.logger)
+        self.instance.function = "my-function"
+
+    def test_execute_should_invoke_and_return_payload(self):
+        payload = b"{}"
+        stream = Mock(name="payload")
+        stream.read.return_value = b"result"
+        self.connection.invoke.return_value = {"Payload": stream}
+
+        result = self.instance.execute(payload)
+
+        assert result == b"result"
+        self.connection.invoke.assert_called_once_with(
+            FunctionName="my-function", Payload=payload
+        )
+
+    def test_execute_when_error_should_log_and_return_none(self):
+        self.connection.invoke.side_effect = ClientError({"Error": {}}, "invoke")
+
+        result = self.instance.execute(b"{}")
+
+        assert result is None
+        self.logger.error.assert_called_once()

--- a/tests/unit/cloud/aws/test_sqs_repository.py
+++ b/tests/unit/cloud/aws/test_sqs_repository.py
@@ -1,3 +1,4 @@
+# pylint: disable=attribute-defined-outside-init, protected-access
 from unittest.mock import Mock
 from botocore.exceptions import ClientError
 
@@ -9,28 +10,30 @@ class TestSqs:
         self.connection = Mock(name="connection")
         self.logger = Mock(name="logger")
         self.instance = Sqs(connection=self.connection, logger=self.logger)
-        self.instance._queue = Mock(name="queue")
+        self.connection.get_queue_by_name.return_value = Mock(name="queue")
+        self.instance.queue = "queue"
+        self.queue = self.connection.get_queue_by_name.return_value
 
     def test_receive_message_should_return_body_and_delete(self):
         message = Mock(name="message")
         message.body = "hello"
-        self.instance._queue.receive_messages.return_value = [message]
+        self.queue.receive_messages.return_value = [message]
 
         result = self.instance.receive_message()
 
         assert result == "hello"
-        self.instance._queue.receive_messages.assert_called_once_with(MaxNumberOfMessages=1)
+        self.queue.receive_messages.assert_called_once_with(MaxNumberOfMessages=1)
         message.delete.assert_called_once_with()
 
     def test_receive_message_when_empty_should_return_empty_string(self):
-        self.instance._queue.receive_messages.return_value = []
+        self.queue.receive_messages.return_value = []
 
         result = self.instance.receive_message()
 
         assert result == ""
 
     def test_receive_message_when_error_should_log_and_return_empty_string(self):
-        self.instance._queue.receive_messages.side_effect = ClientError({"Error": {}}, "receive")
+        self.queue.receive_messages.side_effect = ClientError({"Error": {}}, "receive")
 
         result = self.instance.receive_message()
 

--- a/tests/unit/cloud/aws/test_sqs_repository.py
+++ b/tests/unit/cloud/aws/test_sqs_repository.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+from botocore.exceptions import ClientError
+
+from cloud_components.cloud.aws.repository.sqs import Sqs
+
+
+class TestSqs:
+    def setup_method(self):
+        self.connection = Mock(name="connection")
+        self.logger = Mock(name="logger")
+        self.instance = Sqs(connection=self.connection, logger=self.logger)
+        self.instance._queue = Mock(name="queue")
+
+    def test_receive_message_should_return_body_and_delete(self):
+        message = Mock(name="message")
+        message.body = "hello"
+        self.instance._queue.receive_messages.return_value = [message]
+
+        result = self.instance.receive_message()
+
+        assert result == "hello"
+        self.instance._queue.receive_messages.assert_called_once_with(MaxNumberOfMessages=1)
+        message.delete.assert_called_once_with()
+
+    def test_receive_message_when_empty_should_return_empty_string(self):
+        self.instance._queue.receive_messages.return_value = []
+
+        result = self.instance.receive_message()
+
+        assert result == ""
+
+    def test_receive_message_when_error_should_log_and_return_empty_string(self):
+        self.instance._queue.receive_messages.side_effect = ClientError({"Error": {}}, "receive")
+
+        result = self.instance.receive_message()
+
+        assert result == ""
+        self.logger.error.assert_called_once()


### PR DESCRIPTION
## Summary
- implement boto3 call in Lambda.execute
- add receiving logic in Sqs.receive_message
- add unit tests for Lambda and Sqs repositories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684335281a108327b8aedd1b2b6e1ca0